### PR TITLE
added method to tear down NKScriptContext interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ allprojects {
 ``` gradle
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.github.nodekit-io.nodekit-android:nkscripting:v1.0.18'
-    compile 'com.github.nodekit-io.nodekit-android:nkelectro:v1.0.18'
+    compile 'com.github.nodekit-io.nodekit-android:nkscripting:v1.0.21'
+    compile 'com.github.nodekit-io.nodekit-android:nkelectro:v1.0.21'
 }
 ```
 

--- a/app/src/main/assets/app/index.js
+++ b/app/src/main/assets/app/index.js
@@ -30,6 +30,10 @@ const secondFunction = require("./subdirectory/index")
 
 secondFunction()
 
+setInterval(function() {
+    console.log("timer fire")
+}, 2000)
+
 nodekit.on("ready", function() {
 
            var p = new BrowserWindow({ 'preloadURL': 'internal://localhost/app/index.html',

--- a/app/src/main/java/io/nodekit/nodekitandroid/MainActivity.java
+++ b/app/src/main/java/io/nodekit/nodekitandroid/MainActivity.java
@@ -38,6 +38,8 @@ import android.widget.Button;
 
 public class MainActivity extends Activity implements NKScriptContext.NKScriptContextDelegate, android.view.View.OnClickListener {
 
+    private boolean isRunning = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -63,18 +65,34 @@ public class MainActivity extends Activity implements NKScriptContext.NKScriptCo
     public void onClick(android.view.View v) {
         switch (v.getId()) {
             case  R.id.button: {
-                String script = "process.bootstrap('app/index.js');";
-
-                try {
-                    context.evaluateJavaScript(script, null);
-                    NKEventEmitter.global.emit("NK.AppReady", "");
-                } catch (Exception e) {
-                    NKLogging.log(e);
+                if (this.isRunning) {
+                    stop();
+                } else {
+                    start();
                 }
                 break;
             }
 
         }
+    }
+
+    void start() {
+
+        String script = "process.bootstrap('app/index.js');";
+
+        try {
+            context.evaluateJavaScript(script, null);
+            NKEventEmitter.global.emit("NK.AppReady", "");
+            isRunning = true;
+        } catch (Exception e) {
+            NKLogging.log(e);
+        }
+    }
+
+    void stop() {
+        context.tearDown();
+        context = null;
+        isRunning = false;
     }
 
     public void NKScriptEngineDidLoad(NKScriptContext context) {

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/NKScriptContext.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/NKScriptContext.java
@@ -35,6 +35,8 @@ public interface NKScriptContext
 
     String serialize(Object obj) throws Exception ;
 
+    void tearDown();
+
     interface NKScriptContextDelegate {
 
         void NKScriptEngineDidLoad(NKScriptContext context);

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -21,6 +21,7 @@ package io.nodekit.nkscripting.engines.androidwebview;
 import android.annotation.SuppressLint;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -117,6 +118,20 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
 
     public int id() throws Exception {
         return _id;
+    }
+
+    @Override
+    public void tearDown() {
+
+        _webview.pauseTimers();
+        _webview.getSettings().setJavaScriptEnabled(false);
+        _webview.stopLoading();
+
+        ViewParent parent = _webview.getParent();
+        if (parent instanceof ViewGroup) {
+            ViewGroup group = (ViewGroup)parent;
+            group.removeView(_webview);
+        }
     }
 
     @JavascriptInterface

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -127,11 +127,17 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
         _webview.getSettings().setJavaScriptEnabled(false);
         _webview.stopLoading();
 
+        _sourceList.clear();
+        _scriptMessageHandlers.clear();
+        _injectedPlugins.clear();
+
         ViewParent parent = _webview.getParent();
         if (parent instanceof ViewGroup) {
             ViewGroup group = (ViewGroup)parent;
             group.removeView(_webview);
         }
+
+        _webview = null;
     }
 
     @JavascriptInterface


### PR DESCRIPTION
Implementation of `tearDown()` for a WebView context pauses all timers and sets javascript enabled to false. We also remove the web view from the view hierarchy. This stops all execution and unloads all scripts.