### PR TITLE
Feature/native timers

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="EntryPointsManager">
-    <entry_points version="2.0" />
-  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
@@ -27,17 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ allprojects {
 ``` gradle
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.github.nodekit-io.nodekit-android:nkscripting:v1.0.24'
-    compile 'com.github.nodekit-io.nodekit-android:nkelectro:v1.0.24'
+    compile 'com.github.nodekit-io.nodekit-android:nkscripting:v1.0.25'
+    compile 'com.github.nodekit-io.nodekit-android:nkelectro:v1.0.25'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "io.nodekit.nodekitandroid"

--- a/app/src/main/assets/app/index.js
+++ b/app/src/main/assets/app/index.js
@@ -30,8 +30,11 @@ const secondFunction = require("./subdirectory/index")
 
 secondFunction()
 
+var last = now()
 setInterval(function() {
-    console.log("recurring timer fire")
+    const newTime = now()
+    console.error("delta :" + (newTime - last))
+    last = newTime
 }, 2500)
 
 setTimeout(function() {
@@ -54,3 +57,6 @@ nodekit.on("ready", function() {
            console.log("Server running");
      });
 
+function now() {
+  return new Date().getTime()
+}

--- a/app/src/main/assets/app/index.js
+++ b/app/src/main/assets/app/index.js
@@ -31,8 +31,15 @@ const secondFunction = require("./subdirectory/index")
 secondFunction()
 
 setInterval(function() {
-    console.log("timer fire")
-}, 2000)
+    console.log("recurring timer fire")
+}, 2500)
+
+setTimeout(function() {
+    console.log("single timer fire")
+    setTimeout(function() {
+        console.log("second timer fire")
+    }, 2000)
+}, 15000)
 
 nodekit.on("ready", function() {
 

--- a/app/src/main/java/io/nodekit/nodekitandroid/MainActivity.java
+++ b/app/src/main/java/io/nodekit/nodekitandroid/MainActivity.java
@@ -151,22 +151,13 @@ public class MainActivity extends Activity implements NKScriptContext.NKScriptCo
 
     void bootstrap() {
 
-        Handler handler = new Handler(getMainLooper(), null);
-
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    String script = "process.bootstrap('app/index.js');";
-                    context.evaluateJavaScript(script, null);
-                    NKEventEmitter.global.emit("NK.AppReady", "");
-                    isRunning = true;
-                } catch (Exception e) {
-                    NKLogging.log(e);
-                }
-            }
-        }, 10000);
-
-
+        try {
+            String script = "process.bootstrap('app/index.js');";
+            context.evaluateJavaScript(script, null);
+            NKEventEmitter.global.emit("NK.AppReady", "");
+            isRunning = true;
+        } catch (Exception e) {
+            NKLogging.log(e);
+        }
     }
 }

--- a/app/src/main/java/io/nodekit/nodekitandroid/MainActivity.java
+++ b/app/src/main/java/io/nodekit/nodekitandroid/MainActivity.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.provider.Settings;
 import android.util.Log;
 
@@ -150,14 +151,22 @@ public class MainActivity extends Activity implements NKScriptContext.NKScriptCo
 
     void bootstrap() {
 
-        String script = "process.bootstrap('app/index.js');";
+        Handler handler = new Handler(getMainLooper(), null);
 
-        try {
-            context.evaluateJavaScript(script, null);
-            NKEventEmitter.global.emit("NK.AppReady", "");
-            isRunning = true;
-        } catch (Exception e) {
-            NKLogging.log(e);
-        }
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    String script = "process.bootstrap('app/index.js');";
+                    context.evaluateJavaScript(script, null);
+                    NKEventEmitter.global.emit("NK.AppReady", "");
+                    isRunning = true;
+                } catch (Exception e) {
+                    NKLogging.log(e);
+                }
+            }
+        }, 10000);
+
+
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 14 19:28:36 CDT 2017
+#Mon Nov 06 15:25:06 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/nkcore/build.gradle
+++ b/nkcore/build.gradle
@@ -5,7 +5,7 @@ group='com.github.jitpack'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19

--- a/nkelectro/build.gradle
+++ b/nkelectro/build.gradle
@@ -5,7 +5,7 @@ group='com.github.nodekit-io'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19

--- a/nkscripting/build.gradle
+++ b/nkscripting/build.gradle
@@ -5,7 +5,7 @@ group='com.github.nodekit-io'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19

--- a/nkscripting/build.gradle
+++ b/nkscripting/build.gradle
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 24
-        versionCode 1
+        versionCode 25
         versionName "1.0"
     }
     buildTypes {
@@ -24,5 +24,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
 }

--- a/nkscripting/src/main/assets/lib-scripting/nkscripting.js
+++ b/nkscripting/src/main/assets/lib-scripting/nkscripting.js
@@ -135,7 +135,6 @@
 
     NKScripting.createConstructor = function (channelName, namespace, type) {
         var ctor = function () {
-            debugger;
             // Instance must can be accessed by native object in global context.
             var ctor = this.constructor;
             //    while (ctor[ctor.$lastInstID] != undefined)

--- a/nkscripting/src/main/assets/lib-scripting/timer.js
+++ b/nkscripting/src/main/assets/lib-scripting/timer.js
@@ -1,0 +1,15 @@
+
+function setTimeout(callback, ms) {
+    
+    return NodeKitTimer.setTimeout(callback, ms)
+}
+
+function clearTimeout(indentifier) {
+    
+    NodeKitTimer.clearTimeout(indentifier)
+}
+
+function setInterval(callback, ms) {
+    
+    return NodeKitTimer.setInterval(callback, ms)
+}

--- a/nkscripting/src/main/assets/lib-scripting/timer.js
+++ b/nkscripting/src/main/assets/lib-scripting/timer.js
@@ -1,15 +1,15 @@
 
 function setTimeout(callback, ms) {
     
-    return NodeKitTimer.setTimeout(callback, ms)
+    return NodeKitTimer.setTimeoutSync(callback, ms)
 }
 
 function clearTimeout(indentifier) {
     
-    NodeKitTimer.clearTimeout(indentifier)
+    NodeKitTimer.clearTimeoutSync(indentifier)
 }
 
 function setInterval(callback, ms) {
     
-    return NodeKitTimer.setInterval(callback, ms)
+    return NodeKitTimer.setIntervalSync(callback, ms)
 }

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -191,6 +191,11 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
 
         String script1 = NKStorage.getResource("lib-scripting/nkscripting.js");
 
+        if (script1 != null && script1.isEmpty()) {
+            NKLogging.log("Failed to read provision script: nkscripting", NKLogging.Level.Error);
+            return;
+        }
+
         this.injectJavaScript(new NKScriptSource(script1, "io.nodekit.scripting/NKScripting/nkscripting.js", "nkscripting"));
 
         String appjs = NKStorage.getResource("lib-scripting/init_androidwebview.js");

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -201,7 +201,7 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
 
         String script3 = NKStorage.getResource("lib-scripting/promise.js");
 
-        if (script3.isEmpty()) {
+        if (script3 != null && script3.isEmpty()) {
             NKLogging.log("Failed to read provision script: promise", NKLogging.Level.Error);
             return;
         }

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -225,7 +225,7 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
         String timerSource = NKStorage.getResource("lib-scripting/timer.js");
 
         if (timerSource == null || timerSource.isEmpty()) {
-            NKLogging.log("Failed to read provision script: promise", NKLogging.Level.Error);
+            NKLogging.log("Failed to read provision script: timer", NKLogging.Level.Error);
             return;
         }
 

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -208,6 +208,8 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
 
         this.injectJavaScript(new NKScriptSource(script3, "io.nodekit.scripting/NKScripting/promise.js", "Promise"));
 
+        loadTimerScript();
+
         NKStorage.attachTo(this);
         NKTimer.attachTo(this);
 
@@ -216,6 +218,18 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
        if (_webview.getVisibility() != View.VISIBLE)
           _webview.loadDataWithBaseURL("", "<html><body>NodeKit Running</body></html>", "text/html", "UTF-8", "");
 
+    }
+
+    private void loadTimerScript() throws Exception {
+
+        String timerSource = NKStorage.getResource("lib-scripting/timer.js");
+
+        if (timerSource == null || timerSource.isEmpty()) {
+            NKLogging.log("Failed to read provision script: promise", NKLogging.Level.Error);
+            return;
+        }
+
+        this.injectJavaScript(new NKScriptSource(timerSource, "io.nodekit.scripting/NKScripting/timer.js", "io.nodekit.scripting.timer"));
     }
 
 

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/engines/androidwebview/NKEngineAndroidWebView.java
@@ -44,6 +44,7 @@ import io.nodekit.nkscripting.util.NKSerialize;
 import io.nodekit.nkscripting.channelbridge.NKScriptChannel;
 import io.nodekit.nkscripting.channelbridge.NKScriptMessage;
 import io.nodekit.nkscripting.NKScriptExport.NKScriptExportType;
+import io.nodekit.nkscripting.util.NKTimer;
 
 public class NKEngineAndroidWebView extends WebViewClient implements NKScriptContext, NKScriptMessage.Controller {
 
@@ -208,6 +209,7 @@ public class NKEngineAndroidWebView extends WebViewClient implements NKScriptCon
         this.injectJavaScript(new NKScriptSource(script3, "io.nodekit.scripting/NKScripting/promise.js", "Promise"));
 
         NKStorage.attachTo(this);
+        NKTimer.attachTo(this);
 
         callback.NKScriptEngineDidLoad(this);
 

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
@@ -51,7 +51,7 @@ public class NKTimer implements NKScriptExport {
     }
 
     @JavascriptInterface
-    public String setTimeout(NKScriptValue callback, Double milliseconds) {
+    public String setTimeoutSync(NKScriptValue callback, Double milliseconds) {
 
         Long delay = milliseconds.longValue();
 
@@ -72,7 +72,7 @@ public class NKTimer implements NKScriptExport {
     }
 
     @JavascriptInterface
-    String setInterval(NKScriptValue callback, Double milliseconds) {
+    public String setIntervalSync(NKScriptValue callback, Double milliseconds) {
 
         Long delay = milliseconds.longValue();
 
@@ -93,7 +93,7 @@ public class NKTimer implements NKScriptExport {
     }
 
     @JavascriptInterface
-    void clearTimeout(String identifier) {
+    public void clearTimeoutSync(String identifier) {
 
         NKTimerTask task = tasks.remove(identifier);
 
@@ -116,7 +116,7 @@ public class NKTimer implements NKScriptExport {
 
         if (!task.isRepeating()) {
 
-            clearTimeout(identifier);
+            clearTimeoutSync(identifier);
         }
 
         Handler mainHandler = new Handler(NKApplication.getAppContext().getMainLooper());

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
@@ -51,16 +51,16 @@ public class NKTimer implements NKScriptExport {
     }
 
     @JavascriptInterface
-    public String setTimeoutSync(NKScriptValue callback, Double milliseconds) {
+    public String setTimeoutSync(NKScriptValue callback, Number milliseconds) {
 
         Long delay = milliseconds.longValue();
 
-        String uuid = newUUID();
+        final String uuid = newUUID();
 
         ScheduledFuture<?> future = executor.schedule(new Runnable() {
             @Override
             public void run() {
-
+                handlerTaskFire(uuid);
             }
         }, delay, TimeUnit.MILLISECONDS);
 
@@ -72,7 +72,7 @@ public class NKTimer implements NKScriptExport {
     }
 
     @JavascriptInterface
-    public String setIntervalSync(NKScriptValue callback, Double milliseconds) {
+    public String setIntervalSync(NKScriptValue callback, Number milliseconds) {
 
         Long delay = milliseconds.longValue();
 

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
@@ -20,6 +20,8 @@ package io.nodekit.nkscripting.util;
 
 import android.os.Handler;
 import android.webkit.JavascriptInterface;
+
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -83,7 +85,7 @@ public class NKTimer implements NKScriptExport {
             public void run() {
                 handlerTaskFire(uuid);
             }
-        }, 0, delay, TimeUnit.MILLISECONDS);
+        }, delay, delay, TimeUnit.MILLISECONDS);
 
         NKTimerTask task = new NKTimerTask(future, callback, true);
 
@@ -98,6 +100,16 @@ public class NKTimer implements NKScriptExport {
         NKTimerTask task = tasks.remove(identifier);
 
         if (task != null) {
+
+            task.cancel();
+        }
+    }
+
+    void clearAllTimers() {
+
+        Collection<NKTimerTask> tasks = this.tasks.values();
+
+        for (NKTimerTask task : tasks) {
 
             task.cancel();
         }
@@ -144,5 +156,15 @@ public class NKTimer implements NKScriptExport {
         } while (tasks.get(uuid) != null);
 
         return uuid;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            clearAllTimers();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        super.finalize();
     }
 }

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimer.java
@@ -1,0 +1,148 @@
+/*
+* nodekit.io
+*
+* Copyright (c) 2016 OffGrid Networks. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package io.nodekit.nkscripting.util;
+
+import android.os.Handler;
+import android.webkit.JavascriptInterface;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import io.nodekit.nkscripting.NKApplication;
+import io.nodekit.nkscripting.NKScriptContext;
+import io.nodekit.nkscripting.NKScriptExport;
+import io.nodekit.nkscripting.NKScriptValue;
+
+
+public class NKTimer implements NKScriptExport {
+
+    private static String JS_NAMPESPACE = "NodeKitTimer";
+
+    private ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(100);
+
+    private Map<String, NKTimerTask> tasks = new HashMap<>();
+
+    public static void attachTo( NKScriptContext context) throws Exception {
+        HashMap<String,Object> options = new HashMap<String, Object>();
+
+        options.put("js","lib-scripting/timer.js");
+
+        context.loadPlugin(new NKTimer(), JS_NAMPESPACE, options);
+    }
+
+    @JavascriptInterface
+    public String setTimeout(NKScriptValue callback, Double milliseconds) {
+
+        Long delay = milliseconds.longValue();
+
+        String uuid = newUUID();
+
+        ScheduledFuture<?> future = executor.schedule(new Runnable() {
+            @Override
+            public void run() {
+
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+
+        NKTimerTask task = new NKTimerTask(future, callback, false);
+
+        tasks.put(uuid, task);
+
+        return uuid;
+    }
+
+    @JavascriptInterface
+    String setInterval(NKScriptValue callback, Double milliseconds) {
+
+        Long delay = milliseconds.longValue();
+
+        final String uuid = newUUID();
+
+        ScheduledFuture<?> future = executor.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                handlerTaskFire(uuid);
+            }
+        }, 0, delay, TimeUnit.MILLISECONDS);
+
+        NKTimerTask task = new NKTimerTask(future, callback, true);
+
+        tasks.put(uuid, task);
+
+        return uuid;
+    }
+
+    @JavascriptInterface
+    void clearTimeout(String identifier) {
+
+        NKTimerTask task = tasks.remove(identifier);
+
+        if (task != null) {
+
+            task.cancel();
+        }
+    }
+
+    private void handlerTaskFire(String identifier) {
+
+        final NKTimerTask task = tasks.get(identifier);
+
+        if (task == null) {
+
+            return;
+        }
+
+        final NKScriptValue callback = task.getCallback();
+
+        if (!task.isRepeating()) {
+
+            clearTimeout(identifier);
+        }
+
+        Handler mainHandler = new Handler(NKApplication.getAppContext().getMainLooper());
+
+        Runnable myRunnable = new Runnable() {
+            @Override
+            public void run() {
+
+                Object[] args = new Object[0];
+
+                callback.callWithArguments(args, null);
+            }
+        };
+        mainHandler.post(myRunnable);
+    }
+
+    private String newUUID() {
+
+        String uuid;
+
+        do {
+
+            uuid = UUID.randomUUID().toString();
+
+        } while (tasks.get(uuid) != null);
+
+        return uuid;
+    }
+}

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimerTask.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimerTask.java
@@ -1,0 +1,52 @@
+/*
+* nodekit.io
+*
+* Copyright (c) 2016 OffGrid Networks. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package io.nodekit.nkscripting.util;
+
+import android.support.annotation.NonNull;
+import java.util.concurrent.ScheduledFuture;
+import io.nodekit.nkscripting.NKScriptValue;
+
+public class NKTimerTask {
+
+    private ScheduledFuture<?> future;
+    private NKScriptValue callback;
+    private boolean isRepeating;
+
+    NKTimerTask(@NonNull ScheduledFuture<?> future, @NonNull NKScriptValue callback, @NonNull boolean isRepeating) {
+        this.future = future;
+        this.callback = callback;
+        this.isRepeating = isRepeating;
+    }
+
+    public @NonNull NKScriptValue getCallback() {
+        return callback;
+    }
+
+    boolean isRepeating() {
+        return isRepeating;
+    }
+
+    void cancel() {
+
+        if (future != null) {
+            future.cancel(true);
+            future = null;
+        }
+    }
+}

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimerTask.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/util/NKTimerTask.java
@@ -28,7 +28,7 @@ public class NKTimerTask {
     private NKScriptValue callback;
     private boolean isRepeating;
 
-    NKTimerTask(@NonNull ScheduledFuture<?> future, @NonNull NKScriptValue callback, @NonNull boolean isRepeating) {
+    NKTimerTask(@NonNull ScheduledFuture<?> future, @NonNull NKScriptValue callback, boolean isRepeating) {
         this.future = future;
         this.callback = callback;
         this.isRepeating = isRepeating;


### PR DESCRIPTION
`setTimeout`, `setInterval`, and `clearInterval` have been replaced with native Java implementations. This works around a "feature" of Chrome where pages that are not considered active has their timer's throttled. I can only assume based on observations of this happening, that our page in the invisible webview in the system window is considered inactive. Below are some links related to this issue:

https://developers.google.com/web/updates/2017/03/background_tabs#budget-based_background_timer_throttling
https://www.chromestatus.com/feature/6172836527865856

I've implemented a benchmark in the sample application to test and compare implementations. Here are some observations collected using the benchmark.

Calling `setInterval` with a delay of 2500ms
Chrome timers: Callbacks delivered +/- 600ms from expected delivery time
Native timers: Callbacks delivered +/- 3ms from expected delivery time

I do expect that Chrome's error margin gets worse the long it runs (given the timer budget feature) and when the app is backgrounded (this has been observed and also matches Chrome's documented behavior). Even with the app foregrounded and just having launched the engine, we've seen a two order of magnitude improvement in accuracy with native timers. 

Fixes #17 