### PR TITLE
allow methods ending in -Sync to not return a value

### DIFF
--- a/app/src/main/assets/app/index.js
+++ b/app/src/main/assets/app/index.js
@@ -31,10 +31,15 @@ const secondFunction = require("./subdirectory/index")
 secondFunction()
 
 var last = now()
-setInterval(function() {
+var counter = 0
+var timerId = setInterval(function() {
     const newTime = now()
     console.error("delta :" + (newTime - last))
     last = newTime
+    counter += 1
+    if (counter == 5) {
+        clearTimeout(timerId)
+    }
 }, 2500)
 
 setTimeout(function() {

--- a/nkscripting/src/main/assets/lib-scripting/nkscripting.js
+++ b/nkscripting/src/main/assets/lib-scripting/nkscripting.js
@@ -222,7 +222,10 @@
                 '$operand': operand,
                 '$target': this.$instanceID || 0
             });
-            return JSON.parse(result, JSON.dateParser);
+
+            if (result != 'undefined') {
+                return JSON.parse(result, JSON.dateParser);
+            }
         }
         else
             this.$channel.postMessage({

--- a/nkscripting/src/main/assets/lib-scripting/timer.js
+++ b/nkscripting/src/main/assets/lib-scripting/timer.js
@@ -4,12 +4,12 @@ function setTimeout(callback, ms) {
     return NodeKitTimer.setTimeoutSync(callback, ms)
 }
 
+function setInterval(callback, ms) {
+
+    return NodeKitTimer.setIntervalSync(callback, ms)
+}
+
 function clearTimeout(indentifier) {
     
     NodeKitTimer.clearTimeoutSync(indentifier)
-}
-
-function setInterval(callback, ms) {
-    
-    return NodeKitTimer.setIntervalSync(callback, ms)
 }


### PR DESCRIPTION
It seems like NodeKit expects that any method with the -Sync suffix should return a value. It attempts to pass the result to JSON.parse, but when no value was returned, we get "undefined" which is not valid JSON, throwing an error. This behavior isn't documented anywhere and is unintuitive that a -Sync _must_ return a value or crash. 

This update allows -Sync methods to not return a value, and it's the same behavior as if -Sync was left off (no value returned from `invokeNative`).