### PR TITLE
Feature/oreo webview fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "io.nodekit.nodekitandroid"
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -22,7 +22,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
     compile project(":nkscripting")
     compile project(":nkelectro")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,14 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+ext {
+    supportLibraryVersion = "26.0.2"
 }

--- a/nkcore/build.gradle
+++ b/nkcore/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.jitpack'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -24,5 +24,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
 }

--- a/nkelectro/build.gradle
+++ b/nkelectro/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.nodekit-io'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -24,6 +24,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
     compile project(":nkscripting")
 }

--- a/nkscripting/build.gradle
+++ b/nkscripting/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.nodekit-io'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 25
         versionName "1.0"
     }
@@ -24,5 +24,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
 }

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/NKApplication.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/NKApplication.java
@@ -77,6 +77,7 @@ public class NKApplication {
             WindowManager.LayoutParams params = new WindowManager.LayoutParams(
                     android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
                     android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+                    WindowManager.LayoutParams.TYPE_PHONE,
                     WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
                             | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
                     PixelFormat.TRANSLUCENT
@@ -89,13 +90,13 @@ public class NKApplication {
             params.height = 0;
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                layoutParams.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
+                params.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
             } else {
-                layoutParams.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
+                params.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                layoutParams.flags = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+                params.flags = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
             }
 
             windowManager.addView(webView, params);

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/NKApplication.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/NKApplication.java
@@ -89,14 +89,8 @@ public class NKApplication {
             params.width = 0;
             params.height = 0;
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                params.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
-            } else {
-                params.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
-            }
-
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                params.flags = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+                params.type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
             }
 
             windowManager.addView(webView, params);

--- a/nkscripting/src/main/java/io/nodekit/nkscripting/NKApplication.java
+++ b/nkscripting/src/main/java/io/nodekit/nkscripting/NKApplication.java
@@ -77,7 +77,6 @@ public class NKApplication {
             WindowManager.LayoutParams params = new WindowManager.LayoutParams(
                     android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
                     android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
-                    WindowManager.LayoutParams.TYPE_PHONE,
                     WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
                             | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
                     PixelFormat.TRANSLUCENT
@@ -88,6 +87,16 @@ public class NKApplication {
             params.y = 0;
             params.width = 0;
             params.height = 0;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                layoutParams.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
+            } else {
+                layoutParams.flags = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                layoutParams.flags = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+            }
 
             windowManager.addView(webView, params);
 


### PR DESCRIPTION
Update to support attaching the background WebView to the main window on Oreo. The  WindowManager.LayoutParams.TYPE_PHONE parameter is now deprecated, so we replace it with WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY on devices with Oreo or above. I also updated the Android SDK version across this project so I could get access to the new layout parameter.